### PR TITLE
feat: Add NotifyContext function for signal handling #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,39 +12,75 @@ To install the signals module, use the following command:
 
 ## Usage
 
+### func Wait
+
 Here's a basic example of how to use the `Wait` function from the signals package:
 
 ```go
 package main
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "syscall"
-    "time"
+	"context"
+	"fmt"
+	"syscall"
+	"time"
 
-    "github.com/goaux/signals"
+	"github.com/goaux/signals"
 )
 
 func main() {
-    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-    defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
 
-    fmt.Println("Waiting for SIGINT or SIGTERM...")
-    sig := signals.Wait(ctx, syscall.SIGINT, syscall.SIGTERM)
+	fmt.Println("Waiting for SIGINT or SIGTERM...")
+	sig := signals.Wait(ctx, syscall.SIGINT, syscall.SIGTERM)
 
-    if sig != nil {
-        fmt.Printf("Received signal: %v\n", sig)
-    } else {
-        fmt.Println("Context canceled")
-    }
+	if sig != nil {
+		fmt.Printf("Received signal: %v\n", sig)
+	} else {
+		fmt.Println("Context canceled")
+	}
 }
 ```
 
 This example waits for either SIGINT or SIGTERM for up to one minute. If a
 signal is received, it prints the signal. If the context is canceled (in this
 case, due to timeout), it prints "Context canceled".
+
+### func NotifyContext
+
+`NotifyContext` creates a context that is canceled when a signal is received,
+and runs a provided function with that context. The result of the function is
+returned as is, regardless of whether it is an error.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/goaux/signals"
+	"github.com/goaux/stacktrace/v2"
+)
+
+func main() {
+	ctx := context.Background()
+	err := signals.NotifyContext(ctx, run, os.Interrupt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", stacktrace.Format(err))
+		os.Exit(1)
+	}
+	// Output:
+	// hello
+}
+
+func run(ctx context.Context) error {
+	fmt.Println("hello")
+	return nil
+}
+```
 
 ## API
 
@@ -56,9 +92,21 @@ func Wait(ctx context.Context, signals ...os.Signal) os.Signal
 
 `Wait` waits for the specified OS signals or context cancellation. It returns
 the received signal or nil if the context is canceled.
-
 If no signals are provided, all incoming signals will be relayed. Otherwise,
 only the provided signals will be monitored.
-
 Multiple calls to Wait with the same signals are allowed and will work
 correctly: each call will receive copies of incoming signals independently.
+
+### func NotifyContext
+
+```go
+func NotifyContext(
+	ctx context.Context,
+	run func(context.Context) error,
+	signals ...os.Signal,
+) error {
+```
+
+`NotifyContext` creates a context that is canceled when a signal is received,
+and returns the result of calling `run` with that context. The result of `run`
+is returned as is, regardless of whether it is an error.

--- a/notify.go
+++ b/notify.go
@@ -1,0 +1,20 @@
+package signals
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+// NotifyContext creates a context that is canceled when a signal is received,
+// and returns the result of calling run with that context.
+// The result of run is returned as is, regardless of whether it is an error.
+func NotifyContext(
+	ctx context.Context,
+	run func(context.Context) error,
+	signals ...os.Signal,
+) error {
+	ctx, cancel := signal.NotifyContext(ctx, signals...)
+	defer cancel()
+	return run(ctx)
+}

--- a/notify_test.go
+++ b/notify_test.go
@@ -1,0 +1,25 @@
+package signals_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/goaux/signals"
+)
+
+func Example_notifyContext() {
+	ctx := context.Background()
+	err := signals.NotifyContext(ctx, run, os.Interrupt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+	// Output:
+	// hello
+}
+
+func run(ctx context.Context) error {
+	fmt.Println("hello")
+	return nil
+}

--- a/wait_test.go
+++ b/wait_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goaux/signals"
 )
 
-func Example() {
+func Example_wait() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Add `NotifyContext` function to simplify signal handling by running a function within a context that is canceled upon signal reception. This provides a more concise way to execute code in response to signals without manually managing contexts and cancellation.

The implementation uses `signal.NotifyContext` to create the context and ensures proper cancellation via `defer cancel()`.  Added example and test cases for the new function. Updated documentation to reflect the new functionality.