### PR TITLE
feat: Add signal identification to NotifyContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ signals is a Go module that provides utilities for handling OS signals.
 [![Go Reference](https://pkg.go.dev/badge/github.com/goaux/signals.svg)](https://pkg.go.dev/github.com/goaux/signals)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goaux/signals)](https://goreportcard.com/report/github.com/goaux/signals)
 
+This package offers functionality to create contexts that can be canceled when specific
+OS signals are received, making it easier to implement graceful shutdown or
+interruption handling in applications.
+
+The key feature is `NotifyContext`, which creates a context that is canceled when
+one of the specified signals is received, and executes a function with that context.
+The signal that caused cancellation can be retrieved using `FromContext`.
+
 ## Installation
 
 To install the signals module, use the following command:
@@ -11,6 +19,51 @@ To install the signals module, use the following command:
     go get github.com/goaux/signals
 
 ## Usage
+
+### func NotifyContext and FromContext
+
+`NotifyContext` creates a context that is canceled when a signal is received,
+and runs a provided function with that context. The result of the function is
+returned as is, regardless of whether it is an error.
+
+`FromContext` can be used with the context to retrieve the signal that caused cancellation.
+`context.Cause` can also be used to retrieve the signal within `Canceled`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/goaux/signals"
+	"github.com/goaux/stacktrace/v2"
+	"github.com/goaux/timer"
+)
+
+func main() {
+	ctx := context.Background()
+	err := signals.NotifyContext(ctx, run, os.Interrupt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", stacktrace.Format(err))
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	if err := timer.SleepCause(ctx, 7*time.Second); err != nil {
+		if sig, ok := signals.FromContext(ctx); ok {
+			fmt.Printf("Context was canceled by signal: %v\n", sig)
+			return nil
+		}
+		return err
+	}
+	fmt.Println("hello")
+	return nil
+}
+```
 
 ### func Wait
 
@@ -46,67 +99,3 @@ func main() {
 This example waits for either SIGINT or SIGTERM for up to one minute. If a
 signal is received, it prints the signal. If the context is canceled (in this
 case, due to timeout), it prints "Context canceled".
-
-### func NotifyContext
-
-`NotifyContext` creates a context that is canceled when a signal is received,
-and runs a provided function with that context. The result of the function is
-returned as is, regardless of whether it is an error.
-
-```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"os"
-
-	"github.com/goaux/signals"
-	"github.com/goaux/stacktrace/v2"
-)
-
-func main() {
-	ctx := context.Background()
-	err := signals.NotifyContext(ctx, run, os.Interrupt)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", stacktrace.Format(err))
-		os.Exit(1)
-	}
-	// Output:
-	// hello
-}
-
-func run(ctx context.Context) error {
-	fmt.Println("hello")
-	return nil
-}
-```
-
-## API
-
-### func Wait
-
-```go
-func Wait(ctx context.Context, signals ...os.Signal) os.Signal
-```
-
-`Wait` waits for the specified OS signals or context cancellation. It returns
-the received signal or nil if the context is canceled.
-If no signals are provided, all incoming signals will be relayed. Otherwise,
-only the provided signals will be monitored.
-Multiple calls to Wait with the same signals are allowed and will work
-correctly: each call will receive copies of incoming signals independently.
-
-### func NotifyContext
-
-```go
-func NotifyContext(
-	ctx context.Context,
-	run func(context.Context) error,
-	signals ...os.Signal,
-) error {
-```
-
-`NotifyContext` creates a context that is canceled when a signal is received,
-and returns the result of calling `run` with that context. The result of `run`
-is returned as is, regardless of whether it is an error.

--- a/notify.go
+++ b/notify.go
@@ -1,20 +1,127 @@
+// Package signals provides utilities for handling OS signals in Go applications.
+//
+// This package offers functionality to create contexts that can be canceled when specific
+// OS signals are received, making it easier to implement graceful shutdown or
+// interruption handling in applications.
+//
+// The key feature is [NotifyContext], which creates a context that is canceled when
+// one of the specified signals is received, and executes a function with that context.
+// The signal that caused cancellation can be retrieved using [FromContext].
 package signals
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 )
 
-// NotifyContext creates a context that is canceled when a signal is received,
+// NotifyContext creates a context that is canceled when one of the specified signals is received,
 // and returns the result of calling run with that context.
 // The result of run is returned as is, regardless of whether it is an error.
+//
+// The function takes a parent context, a function to run with the created context, and
+// a list of signals to watch for. When one of these signals is received, the context
+// is canceled with a Canceled error that wraps the signal.
+//
+// [FromContext] can be used with the context to retrieve the signal that caused cancellation.
+// [context.Cause] can also be used to retrieve the signal within [Canceled].
 func NotifyContext(
-	ctx context.Context,
+	parent context.Context,
 	run func(context.Context) error,
 	signals ...os.Signal,
 ) error {
-	ctx, cancel := signal.NotifyContext(ctx, signals...)
-	defer cancel()
-	return run(ctx)
+	ctx, cancel := context.WithCancelCause(parent)
+	defer cancel(nil)
+	c := &signalCtx{
+		Context: ctx,
+		signals: signals,
+	}
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, signals...)
+	defer signal.Stop(ch)
+	if ctx.Err() == nil {
+		go func() {
+			select {
+			case sig := <-ch:
+				cancel(Canceled{signal: sig})
+			case <-ctx.Done():
+			}
+		}()
+	}
+	return run(c)
+}
+
+// FromContext retrieves the signal that caused a context to be canceled.
+//
+// If the context was canceled by [NotifyContext] due to receiving a signal,
+// FromContext returns that signal and true. Otherwise, it returns nil and false.
+//
+// Example:
+//
+//	if sig, ok := signals.FromContext(ctx); ok {
+//		fmt.Printf("Context was canceled by signal: %v\n", sig)
+//	}
+func FromContext(ctx context.Context) (signal os.Signal, ok bool) {
+	var err Canceled
+	if errors.As(context.Cause(ctx), &err) {
+		return err.Signal(), true
+	}
+	return
+}
+
+// Canceled is an error that wraps context.Canceled and includes the OS signal
+// that caused the cancellation.
+//
+// It implements the error interface and provides methods to access the underlying
+// signal and unwrap to context.Canceled.
+type Canceled struct {
+	signal os.Signal
+}
+
+// Error returns the error message, which includes the context.Canceled error
+// and the string representation of the signal.
+func (s Canceled) Error() string {
+	return fmt.Sprintf("%v (%s)", context.Canceled, s.signal.String())
+}
+
+// Unwrap returns the underlying context.Canceled error.
+func (s Canceled) Unwrap() error {
+	return context.Canceled
+}
+
+// Signal returns the OS signal that caused the cancellation.
+func (s Canceled) Signal() os.Signal {
+	return s.signal
+}
+
+type signalCtx struct {
+	context.Context
+	signals []os.Signal
+}
+
+type stringer interface {
+	String() string
+}
+
+func (c *signalCtx) String() string {
+	var buf []byte
+	// We know that the type of c.Context is context.cancelCtx, and we know that the
+	// String method of cancelCtx returns a string that ends with ".WithCancel".
+	name := c.Context.(stringer).String()
+	name = name[:len(name)-len(".WithCancel")]
+	buf = append(buf, "signals.NotifyContext("+name...)
+	if len(c.signals) != 0 {
+		buf = append(buf, ", ["...)
+		for i, s := range c.signals {
+			buf = append(buf, s.String()...)
+			if i != len(c.signals)-1 {
+				buf = append(buf, ' ')
+			}
+		}
+		buf = append(buf, ']')
+	}
+	buf = append(buf, ')')
+	return string(buf)
 }

--- a/notify_test.go
+++ b/notify_test.go
@@ -2,24 +2,35 @@ package signals_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/goaux/signals"
 )
 
 func Example_notifyContext() {
 	ctx := context.Background()
-	err := signals.NotifyContext(ctx, run, os.Interrupt)
+	err := signals.NotifyContext(ctx, runN, syscall.SIGINT, syscall.SIGTERM)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
 	// Output:
-	// hello
+	// signals.NotifyContext(context.Background, [interrupt terminated])
+	// context canceled (interrupt)
+	// true
+	// interrupt true
 }
 
-func run(ctx context.Context) error {
-	fmt.Println("hello")
+func runN(ctx context.Context) error {
+	fmt.Println(ctx)
+	syscall.Kill(os.Getpid(), syscall.SIGINT)
+	<-ctx.Done()
+	err := context.Cause(ctx)
+	fmt.Println(err.Error())
+	fmt.Println(errors.Is(err, context.Canceled))
+	fmt.Println(signals.FromContext(ctx))
 	return nil
 }

--- a/wait.go
+++ b/wait.go
@@ -1,4 +1,3 @@
-// Package signals provides utilities for handling OS signals.
 package signals
 
 import (


### PR DESCRIPTION
Added `FromContext` to retrieve the signal that canceled a context, and updated `NotifyContext` to wrap signals in a `Canceled` error. Documentation and tests were updated to demonstrate signal detection. This enables graceful handling of OS signals in applications.

Closes #3 